### PR TITLE
Opti: make new() a const fn

### DIFF
--- a/async-barrier/Cargo.toml
+++ b/async-barrier/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["asynchronous", "concurrency"]
 readme = "../README.md"
 
 [dependencies]
-async-mutex = "1.1.5"
+async-mutex = { path = "../async-mutex", version = "1.4.0" }
 event-listener = "2.4.0"
 
 [dev-dependencies]

--- a/async-barrier/src/lib.rs
+++ b/async-barrier/src/lib.rs
@@ -37,7 +37,7 @@ impl Barrier {
     ///
     /// let barrier = Barrier::new(5);
     /// ```
-    pub fn new(n: usize) -> Barrier {
+    pub const fn new(n: usize) -> Barrier {
         Barrier {
             n,
             state: Mutex::new(State {

--- a/async-mutex/Cargo.toml
+++ b/async-mutex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-mutex"
-version = "1.3.0"
+version = "1.4.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2018"
 description = "Async mutex"

--- a/async-mutex/src/lib.rs
+++ b/async-mutex/src/lib.rs
@@ -62,7 +62,7 @@ impl<T> Mutex<T> {
     ///
     /// let mutex = Mutex::new(0);
     /// ```
-    pub fn new(data: T) -> Mutex<T> {
+    pub const fn new(data: T) -> Mutex<T> {
         Mutex {
             state: AtomicUsize::new(0),
             lock_ops: Event::new(),

--- a/async-rwlock/Cargo.toml
+++ b/async-rwlock/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["asynchronous", "concurrency"]
 readme = "../README.md"
 
 [dependencies]
-async-mutex = "1.1.5"
+async-mutex = { path = "../async-mutex", version = "1.4.0" }
 event-listener = "2.4.0"
 
 [dev-dependencies]

--- a/async-rwlock/src/lib.rs
+++ b/async-rwlock/src/lib.rs
@@ -101,7 +101,7 @@ impl<T> RwLock<T> {
     ///
     /// let lock = RwLock::new(0);
     /// ```
-    pub fn new(t: T) -> RwLock<T> {
+    pub const fn new(t: T) -> RwLock<T> {
         RwLock {
             mutex: Mutex::new(()),
             no_readers: Event::new(),

--- a/async-semaphore/src/lib.rs
+++ b/async-semaphore/src/lib.rs
@@ -27,7 +27,7 @@ impl Semaphore {
     ///
     /// let s = Semaphore::new(5);
     /// ```
-    pub fn new(n: usize) -> Semaphore {
+    pub const fn new(n: usize) -> Semaphore {
         Semaphore {
             count: AtomicUsize::new(n),
             event: Event::new(),


### PR DESCRIPTION
Since the `event-listener` constructor is a const fn, all constructors of this repository can be too :)
